### PR TITLE
fix: switch jwt library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Cachaça
 [![codecov](https://codecov.io/github/unsafesystems/cachaca/branch/master/graph/badge.svg?token=PNMZFT2LGU)](https://codecov.io/github/unsafesystems/cachaca)
+[![Go Reference](https://pkg.go.dev/badge/github.com/unsafesystems/cachaca.svg)](https://pkg.go.dev/github.com/unsafesystems/cachaca)
 
 Cachaça (Portuguese pronunciation: [kaˈʃasɐ](https://dictionary.cambridge.org/pronunciation/english/cachaca)) is a 
 distilled spirit made from fermented sugarcane juice. Also known as pinga, caninha, and other names, it is the most 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type AuthenticationKey struct{}

--- a/authentication.go
+++ b/authentication.go
@@ -2,9 +2,9 @@ package cachaca
 
 import (
 	"context"
+	"github.com/golang-jwt/jwt/v5"
 	"reflect"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/rs/zerolog/log"
 	auth2 "github.com/unsafesystems/cachaca/auth"

--- a/authentication.go
+++ b/authentication.go
@@ -2,9 +2,9 @@ package cachaca
 
 import (
 	"context"
-	"github.com/golang-jwt/jwt/v5"
 	"reflect"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/rs/zerolog/log"
 	auth2 "github.com/unsafesystems/cachaca/auth"

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/unsafesystems/cachaca
 go 1.20
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-gonic/gin v1.9.0
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.5

--- a/go.sum
+++ b/go.sum
@@ -60,7 +60,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
@@ -120,6 +119,8 @@ github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFG
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/server.go
+++ b/server.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
+
 	"github.com/unsafesystems/cachaca/internal/logger"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"

--- a/server_test.go
+++ b/server_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/golang/protobuf/proto"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -55,9 +55,9 @@ func TestServer_WithJwtKeyFunc(t *testing.T) {
 }
 
 func TestServer_WithJwtToken(t *testing.T) {
-	s, err := NewServer(WithJwtToken(jwt.StandardClaims{}))
+	s, err := NewServer(WithJwtToken(jwt.RegisteredClaims{}))
 	assert.Nil(t, err)
-	assert.Equal(t, jwt.StandardClaims{}, s.jwtToken)
+	assert.Equal(t, jwt.RegisteredClaims{}, s.jwtToken)
 }
 
 func TestServer(t *testing.T) {


### PR DESCRIPTION
Due to https://deps.dev/advisory/osv/GO-2020-0017 we have to switch the jwt library. Also as of May 21, 2022 the package is depreciated and they recommend to move to the other repo.